### PR TITLE
bug(normalizer): non-gmail email address normalization

### DIFF
--- a/tests/email.test.ts
+++ b/tests/email.test.ts
@@ -45,16 +45,32 @@ describe('Email Validation', () => {
  */
 describe('Email Normalization', () => {
   /**
-   * Tests that email addresses are correctly normalized. Verifies handling of
-   * mixed case, dots in local part, and plus addressing.
+   * Tests that non-Gmail email addresses are correctly normalized. Verifies
+   * handling of mixed case, dots in local part, and plus addressing.
    */
-  test('normalizes email addresses correctly', () => {
+  test('normalizes non-Gmail email addresses correctly', () => {
     expect(normalizeEmail('Test.User@Example.com')).toBe(
-      'testuser@example.com',
+      'test.user@example.com',
     );
     expect(normalizeEmail('test.user+label@example.com')).toBe(
-      'testuser@example.com',
+      'test.user+label@example.com',
     );
+  });
+
+  /**
+   * Tests that Gmail email addresses are correctly normalized. Verifies
+   * handling of mixed case, dots in local part, and plus addressing.
+   */
+  test('normalizes Gmail addresses according to Gmail rules', () => {
+    // Test dot removal
+    expect(normalizeEmail('test.user@gmail.com')).toBe('testuser@gmail.com');
+    expect(normalizeEmail('t.e.s.t@gmail.com')).toBe('test@gmail.com');
+    
+    // Test plus sign removal
+    expect(normalizeEmail('test+label@gmail.com')).toBe('test@gmail.com');
+    
+    // Test both dot and plus sign removal
+    expect(normalizeEmail('test.user+label@gmail.com')).toBe('testuser@gmail.com');
   });
 
   /**
@@ -72,6 +88,7 @@ describe('Email Normalization', () => {
    */
   test('preserves domain part', () => {
     expect(normalizeEmail('test@EXAMPLE.COM')).toBe('test@example.com');
+    expect(normalizeEmail('test@GMAIL.COM')).toBe('test@gmail.com');
   });
 
   /**
@@ -80,7 +97,10 @@ describe('Email Normalization', () => {
    */
   test('removes whitespace', () => {
     expect(normalizeEmail(' test.user @ example.com ')).toBe(
-      'testuser@example.com',
+      'test.user@example.com',
+    );
+    expect(normalizeEmail(' test.user @ gmail.com ')).toBe(
+      'testuser@gmail.com',
     );
   });
 });

--- a/utils/email/normalize.ts
+++ b/utils/email/normalize.ts
@@ -79,13 +79,16 @@ export const normalizeEmail = (
     // Initialize the processed local part with the original local part.
     let processedLocalPart = localPart;
 
-    // Remove all dots from the local part if the option is set to true.
-    if (options.removeDots) {
+    // Evaluate if the option to remove dots is set to true and the domain is
+    // a Gmail address. If so, remove all dots from the local part.
+    if (options.removeDots && domain === 'gmail.com') {
       processedLocalPart = processedLocalPart.replace(/\./g, '');
     }
 
-    // Remove everything after the plus sign if the option is set to true.
-    if (options.removePlusSign) {
+    // Evaluate if the option to remove the plus sign is set to true and the
+    // domain is a Gmail address. If so, remove everything after the plus sign
+    // in the local part.
+    if (options.removePlusSign && domain === 'gmail.com') {
       processedLocalPart = processedLocalPart.split('+')[0];
     }
 


### PR DESCRIPTION
The bug fix resolves an issue where email normalization logic, designed to remove dots from the local part of Gmail addresses, was incorrectly applied to all email addresses, regardless of domain. For non-Gmail addresses, dots and plus signs in the local part are now preserved.

- dots and plus sign removal are only applied if the domain is `gmail.com` and the respective options `removeDots` and `removePlusSign` are `true`.
- add Gmail-specific normalization rules to test suite `email.test`

Closes: #9