### PR TITLE
refactor(web): replace crypto-js and file-saver with platform APIs

### DIFF
--- a/.agents/rules/web-native-apis.mdc
+++ b/.agents/rules/web-native-apis.mdc
@@ -1,0 +1,20 @@
+---
+description: Prefer native platform APIs over utility libraries for web deps
+globs: apps/web/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# Prefer native JavaScript / Web APIs
+
+Minimize bundle size, attack surface, and maintenance cost. Reach for platform APIs before adding imports or changing dependencies.
+
+## Must
+
+- Prefer Web Crypto (`crypto.subtle`) for hashing and related crypto; do not add `crypto-js` or similar.
+- Prefer `URL.createObjectURL` + temporary `<a download>` (or the shared `utils/download/blob` helper) for file downloads; do not add `file-saver`.
+- Prefer built-ins (`fetch`, `URL`, `URLSearchParams`, `TextEncoder`/`TextDecoder`, `structuredClone`, etc.) over small utility packages when they cover the need.
+
+## Must not
+
+- Add a third-party dependency solely to wrap a one-liner platform API.
+- Reintroduce removed packages (`crypto-js`, `file-saver`) without a documented platform gap.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,15 +14,11 @@
     "@fontsource/sora": "catalog:",
     "@mui/icons-material": "catalog:",
     "@mui/material": "catalog:",
-    "@types/file-saver": "catalog:",
-    "crypto-js": "catalog:",
-    "file-saver": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-router-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/crypto-js": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/apps/web/src/hooks/use-email-processor.ts
+++ b/apps/web/src/hooks/use-email-processor.ts
@@ -10,7 +10,7 @@ interface UseEmailProcessorResult {
   clearResults: () => void;
   email: string;
   error: string;
-  processEmail: () => void;
+  processEmail: () => Promise<void>;
   result: EmailHashResult;
   setEmail: (email: string) => void;
 }
@@ -27,7 +27,7 @@ export const useEmailProcessor = (): UseEmailProcessorResult => {
     sha256Hash: "",
   });
 
-  const processEmail = useCallback(() => {
+  const processEmail = useCallback(async () => {
     if (!email) {
       return;
     }
@@ -40,7 +40,7 @@ export const useEmailProcessor = (): UseEmailProcessorResult => {
 
     setError("");
     const normalized = normalizeEmail(email);
-    setResult(generateEmailHashes(normalized));
+    setResult(await generateEmailHashes(normalized));
   }, [email]);
 
   const clearResults = useCallback(() => {

--- a/apps/web/src/hooks/use-phone-processor.ts
+++ b/apps/web/src/hooks/use-phone-processor.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { PhoneHashResult } from "@/types/phone";
-import { generateBase64Hash, generateSha256Hash } from "@/utils/hash/generate";
+import { generateSha256Pair } from "@/utils/hash/generate";
 import { normalizePhone, validatePhone } from "@/utils/phone/normalize";
 
 /**
@@ -10,7 +10,7 @@ interface UsePhoneProcessorResult {
   clearResults: () => void;
   error: string;
   phoneNumber: string;
-  processPhone: () => void;
+  processPhone: () => Promise<void>;
   result: PhoneHashResult;
   setPhoneNumber: (phone: string) => void;
 }
@@ -18,11 +18,17 @@ interface UsePhoneProcessorResult {
 /**
  * Builds hash fields for a phone that has already been normalized.
  */
-const generatePhoneHashes = (normalizedPhone: string): PhoneHashResult => ({
-  base64Hash: generateBase64Hash(normalizedPhone),
-  normalizedPhone,
-  sha256Hash: generateSha256Hash(normalizedPhone),
-});
+const generatePhoneHashes = async (
+  normalizedPhone: string,
+): Promise<PhoneHashResult> => {
+  const { base64, sha256 } = await generateSha256Pair(normalizedPhone);
+
+  return {
+    base64Hash: base64,
+    normalizedPhone,
+    sha256Hash: sha256,
+  };
+};
 
 /**
  * Manages phone input state, validation, normalization, and hash generation.
@@ -36,7 +42,7 @@ export const usePhoneProcessor = (): UsePhoneProcessorResult => {
     sha256Hash: "",
   });
 
-  const processPhone = useCallback(() => {
+  const processPhone = useCallback(async () => {
     if (!phoneNumber) {
       return;
     }
@@ -50,7 +56,7 @@ export const usePhoneProcessor = (): UsePhoneProcessorResult => {
 
     setError("");
     const normalized = normalizePhone(phoneNumber);
-    setResult(generatePhoneHashes(normalized));
+    setResult(await generatePhoneHashes(normalized));
   }, [phoneNumber]);
 
   const clearResults = useCallback(() => {

--- a/apps/web/src/pages/BatchNormalizer/index.tsx
+++ b/apps/web/src/pages/BatchNormalizer/index.tsx
@@ -8,10 +8,10 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { saveAs } from "file-saver";
 import { useCallback, useRef, useState } from "react";
 import type { ProcessedData } from "@/types/csv";
 import { processCSV } from "@/utils/csv/process";
+import { downloadBlob } from "@/utils/download/blob";
 
 /**
  * Uploads a CSV of emails/phones, normalizes rows, and offers a hashed export.
@@ -71,7 +71,7 @@ export const BatchNormalizer = () => {
     ].join("\n");
 
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8" });
-    saveAs(blob, "processed_data.csv");
+    downloadBlob(blob, "processed_data.csv");
   }, [processedData]);
 
   const handleDragOver = useCallback((event: React.DragEvent) => {

--- a/apps/web/src/utils/csv/process.ts
+++ b/apps/web/src/utils/csv/process.ts
@@ -1,6 +1,6 @@
 import type { ProcessedData, ProcessedRow } from "@/types/csv";
 import { normalizeEmail, validateEmail } from "@/utils/email/normalize";
-import { generateBase64Hash, generateSha256Hash } from "@/utils/hash/generate";
+import { generateSha256Pair } from "@/utils/hash/generate";
 import { normalizePhone } from "@/utils/phone/normalize";
 
 const PHONE_CANDIDATE_REGEX = /^[+\d\s\-()]+$/;
@@ -31,7 +31,6 @@ export const detectValueType = (
  */
 export const processCSV = async (file: File): Promise<ProcessedData> => {
   const MAX_RECORDS = 10_000;
-  const rows: ProcessedRow[] = [];
   let skippedRows = 0;
 
   try {
@@ -44,6 +43,8 @@ export const processCSV = async (file: File): Promise<ProcessedData> => {
     if (lines.length > MAX_RECORDS) {
       throw new Error(`File exceeds maximum record limit of ${MAX_RECORDS}`);
     }
+
+    const pending: Array<{ normalized: string; original: string }> = [];
 
     for (const line of lines) {
       const values = line.split(",");
@@ -64,16 +65,23 @@ export const processCSV = async (file: File): Promise<ProcessedData> => {
       }
 
       if (normalized) {
-        rows.push({
-          base64: generateBase64Hash(normalized),
-          normalized,
-          original: values[0],
-          sha256: generateSha256Hash(normalized),
-        });
+        pending.push({ normalized, original: values[0] });
       } else {
         skippedRows += 1;
       }
     }
+
+    const rows: ProcessedRow[] = await Promise.all(
+      pending.map(async ({ normalized, original }) => {
+        const { base64, sha256 } = await generateSha256Pair(normalized);
+        return {
+          base64,
+          normalized,
+          original,
+          sha256,
+        };
+      }),
+    );
 
     return {
       headers: ["Input", "Normalized", "SHA256", "Base64"],

--- a/apps/web/src/utils/download/blob.ts
+++ b/apps/web/src/utils/download/blob.ts
@@ -1,0 +1,12 @@
+/**
+ * Triggers a browser download for `blob` under `filename`.
+ */
+export const downloadBlob = (blob: Blob, filename: string): void => {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  anchor.click();
+  URL.revokeObjectURL(url);
+};

--- a/apps/web/src/utils/hash/generate.ts
+++ b/apps/web/src/utils/hash/generate.ts
@@ -1,32 +1,59 @@
-import CryptoJS from "crypto-js";
 import type { EmailHashResult } from "@/types/email";
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Digests `value` with SHA-256 via the Web Crypto API.
+ */
+const sha256Digest = async (value: string): Promise<ArrayBuffer> =>
+  crypto.subtle.digest("SHA-256", textEncoder.encode(value));
+
+/**
+ * Formats a digest as lowercase hex.
+ */
+const toHex = (buffer: ArrayBuffer): string =>
+  [...new Uint8Array(buffer)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+/**
+ * Formats a digest as standard Base64.
+ */
+const toBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+};
 
 /**
  * Returns the hex SHA-256 digest of `value`, or an empty string when blank.
  */
-export const generateSha256Hash = (value: string): string => {
+export const generateSha256Hash = async (value: string): Promise<string> => {
   if (!value) {
     return "";
   }
-  return CryptoJS.SHA256(value).toString(CryptoJS.enc.Hex);
+  return toHex(await sha256Digest(value));
 };
 
 /**
  * Returns the Base64 SHA-256 digest of `value`, or an empty string when blank.
  */
-export const generateBase64Hash = (value: string): string => {
+export const generateBase64Hash = async (value: string): Promise<string> => {
   if (!value) {
     return "";
   }
-  return CryptoJS.enc.Base64.stringify(CryptoJS.SHA256(value));
+  return toBase64(await sha256Digest(value));
 };
 
 /**
  * Builds the email hash result object from a normalized address.
  */
-export const generateEmailHashes = (
+export const generateEmailHashes = async (
   normalizedEmail: string,
-): EmailHashResult => {
+): Promise<EmailHashResult> => {
   if (!normalizedEmail) {
     return {
       base64Hash: "",
@@ -35,9 +62,29 @@ export const generateEmailHashes = (
     };
   }
 
+  const digest = await sha256Digest(normalizedEmail);
+
   return {
-    base64Hash: generateBase64Hash(normalizedEmail),
+    base64Hash: toBase64(digest),
     normalizedEmail,
-    sha256Hash: generateSha256Hash(normalizedEmail),
+    sha256Hash: toHex(digest),
+  };
+};
+
+/**
+ * Builds hex and Base64 SHA-256 digests from one Web Crypto pass.
+ */
+export const generateSha256Pair = async (
+  value: string,
+): Promise<{ base64: string; sha256: string }> => {
+  if (!value) {
+    return { base64: "", sha256: "" };
+  }
+
+  const digest = await sha256Digest(value);
+
+  return {
+    base64: toBase64(digest),
+    sha256: toHex(digest),
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,12 +24,6 @@ catalogs:
     '@mui/material':
       specifier: 7.3.11
       version: 7.3.11
-    '@types/crypto-js':
-      specifier: 4.2.2
-      version: 4.2.2
-    '@types/file-saver':
-      specifier: 2.0.7
-      version: 2.0.7
     '@types/node':
       specifier: 22.20.1
       version: 22.20.1
@@ -42,12 +36,6 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: 6.0.4
       version: 6.0.4
-    crypto-js:
-      specifier: 4.2.0
-      version: 4.2.0
-    file-saver:
-      specifier: 2.0.5
-      version: 2.0.5
     react:
       specifier: 19.2.8
       version: 19.2.8
@@ -101,15 +89,6 @@ importers:
       '@mui/material':
         specifier: 'catalog:'
         version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@types/file-saver':
-        specifier: 'catalog:'
-        version: 2.0.7
-      crypto-js:
-        specifier: 'catalog:'
-        version: 4.2.0
-      file-saver:
-        specifier: 'catalog:'
-        version: 2.0.5
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -120,9 +99,6 @@ importers:
         specifier: 'catalog:'
         version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
-      '@types/crypto-js':
-        specifier: 'catalog:'
-        version: 4.2.2
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -1094,17 +1070,11 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
-  '@types/crypto-js@4.2.2':
-    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
-
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/file-saver@2.0.7':
-    resolution: {integrity: sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1336,10 +1306,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1505,9 +1471,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  file-saver@2.0.5:
-    resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -3115,13 +3078,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/crypto-js@4.2.2': {}
-
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
-
-  '@types/file-saver@2.0.7': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3346,8 +3305,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  crypto-js@4.2.0: {}
-
   csstype@3.2.3: {}
 
   debounce-fn@6.0.0:
@@ -3522,8 +3479,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  file-saver@2.0.5: {}
 
   fill-range@7.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,14 +11,10 @@ catalog:
   '@emotion/styled': 11.14.1
   '@mui/icons-material': 7.3.11
   '@mui/material': 7.3.11
-  '@types/crypto-js': 4.2.2
-  '@types/file-saver': 2.0.7
   '@types/node': 22.20.1
   '@types/react': 19.2.17
   '@types/react-dom': 19.2.3
   '@vitejs/plugin-react': 6.0.4
-  crypto-js: 4.2.0
-  file-saver: 2.0.5
   react: 19.2.8
   react-doctor: 0.9.1
   react-dom: 19.2.8


### PR DESCRIPTION
Remove unmaintained hashing and download utilities in favor of Web Crypto and native blob downloads to shrink the client bundle, reduce supply-chain exposure, and cut dependency maintenance. Hash helpers are now async to match `crypto.subtle`, while CSV export behavior stays the same for users.

* Rewrite SHA-256 hex and Base64 generation with `crypto.subtle.digest` and `btoa`.
* Make email, phone, and CSV processors await the async hash helpers, including a shared digest pair path.
* Add `utils/download/blob` and use it for batch CSV export instead of `file-saver`.
* Drop `crypto-js`, `file-saver`, and their type packages from the web app and pnpm catalog.
* Add an agent rule preferring native Web APIs over new utility libraries.