### PR TITLE
docs(agents): add architecture guide and refresh project docs

### DIFF
--- a/.agents/commands/check.md
+++ b/.agents/commands/check.md
@@ -1,0 +1,14 @@
+# Check
+
+Run the project Biome CI gate (same command as GitHub Actions lint).
+
+## Steps
+
+1. From the repository root:
+
+   ```bash
+   pnpm exec biome ci .
+   ```
+
+2. Report exit status and any remaining diagnostics.
+3. Do not edit `biome.jsonc` or add `biome-ignore` unless the user explicitly asks.

--- a/.agents/commands/doctor.md
+++ b/.agents/commands/doctor.md
@@ -1,0 +1,16 @@
+# Doctor
+
+Follow the project react-doctor skill and scan React diagnostics.
+
+## Steps
+
+1. Read [`.agents/skills/react-doctor/SKILL.md`](.agents/skills/react-doctor/SKILL.md) (and `reference.md` if needed).
+2. From the repository root, run:
+
+   ```bash
+   pnpm doctor:changed
+   ```
+
+3. If the user asked for a full scan, run `pnpm doctor:full` instead.
+4. Summarize score / findings and fix regressions before finishing the task.
+5. Do **not** use `npx react-doctor@latest`.

--- a/.agents/commands/verify.md
+++ b/.agents/commands/verify.md
@@ -1,0 +1,20 @@
+# Verify
+
+Run Biome CI and the web production build. Treat either failure as blocking.
+
+## Steps
+
+1. From the repository root:
+
+   ```bash
+   pnpm exec biome ci .
+   ```
+
+2. Then:
+
+   ```bash
+   pnpm build
+   ```
+
+3. If either command fails, fix the issues and re-run until both succeed.
+4. Report a short summary of results when done.

--- a/.agents/docs/ARCHITECTURE.md
+++ b/.agents/docs/ARCHITECTURE.md
@@ -1,0 +1,193 @@
+# DII Operator architecture
+
+This document gives the high-level system architecture of the DII Operator web app.
+
+## Purpose and scope
+
+DII Operator is a **client-only** SPA.
+It normalizes and hashes **emails** and **phone numbers** using UID2-oriented rules.
+It can also process a one-column **CSV** batch and download hashed results.
+
+This file covers:
+
+- The monorepo and `apps/web` module map
+- Single-value and CSV data flows
+- Routing, shell layout, and GitHub Pages hosting
+- Hashing posture (Web Crypto)
+- Build and deploy shape
+- Extension points at a high level
+
+This file does **not** cover:
+
+- Full product usage — see [README.md](../../README.md)
+- Normalize/hash edit rules — see [dii-normalize](../skills/dii-normalize/SKILL.md) and [reference.md](../skills/dii-normalize/reference.md)
+- Agent index — see [AGENTS.md](../../AGENTS.md)
+
+## System context
+
+The user opens the static site in a browser.
+The Vite SPA runs entirely in the client.
+Normalization and SHA-256 digests use the **Web Crypto** API in that browser.
+There is no application BFF and no server-side hashing.
+
+GitHub Pages hosts the built files under the `/dii-operator/` base path.
+
+```mermaid
+flowchart LR
+  User[BrowserUser] --> Spa[ViteReactSPA]
+  Spa --> WebCrypto[WebCryptoSHA256]
+  Spa --> Pages[GitHubPagesStaticHost]
+```
+
+## High-level flows
+
+### Single email or phone
+
+1. The page collects input and calls a processor hook.
+2. The hook validates, then normalizes via `utils/email` or `utils/phone`.
+3. The hook awaits hash helpers in `utils/hash`.
+4. The page renders normalized value, hex digest, and Base64 digest via `ResultDisplay`.
+
+```mermaid
+flowchart TD
+  Page[EmailOrPhonePage] --> Hook[ProcessorHook]
+  Hook --> Validate[Validate]
+  Validate --> Normalize[Normalize]
+  Normalize --> Hash[WebCryptoHash]
+  Hash --> UI[ResultDisplay]
+```
+
+### CSV batch
+
+1. `BatchNormalizer` accepts a CSV file (drag/drop or file picker).
+2. `processCSV` reads text, classifies each cell as email, phone, or unknown, and hashes accepted rows.
+3. The page builds a CSV string and downloads it with `downloadBlob`.
+
+Unknown or invalid rows increment `skippedRows`.
+Non-empty line count must stay at or under `10_000`.
+
+```mermaid
+flowchart TD
+  Upload[CsvUpload] --> Process[processCSV]
+  Process --> Classify[DetectEmailOrPhone]
+  Classify --> HashRows[HashAcceptedRows]
+  HashRows --> Download[downloadBlob]
+```
+
+## Module map
+
+Application source lives under [`apps/web/src`](../../apps/web/src).
+
+| Area | Role |
+| ---- | ---- |
+| `index.tsx` | Theme provider, CssBaseline, Sora font imports, React root |
+| `app.tsx` | `BrowserRouter` with basename `/dii-operator` |
+| `routes/app-routes.tsx` | Nested routes under `MainLayout` |
+| `pages/` | Overview, Email, Phone, Batch screens |
+| `hooks/` | Email and phone process state machines |
+| `utils/email` | Email validate and normalize |
+| `utils/phone` | Phone validate and normalize |
+| `utils/hash` | Async SHA-256 hex and Base64 digests |
+| `utils/csv` | Batch classify, normalize, hash |
+| `utils/download` | Native blob download helper |
+| `components/core` | Leaf UI (for example `CopyButton`) |
+| `components/patterns` | Composed UI (for example `ResultDisplay`) |
+| `components/layouts` | App chrome (`MainLayout`) |
+| `types/` | Shared TypeScript contracts |
+| `styles/theme.ts` | MUI dark navy theme |
+
+```mermaid
+flowchart TB
+  Index[index] --> App[app]
+  App --> Routes[routes]
+  Routes --> Layout[layouts/MainLayout]
+  Layout --> Pages[pages]
+  Pages --> Hooks[hooks]
+  Pages --> Patterns[patterns]
+  Hooks --> EmailUtil[utils/email]
+  Hooks --> PhoneUtil[utils/phone]
+  Hooks --> HashUtil[utils/hash]
+  Pages --> CsvUtil[utils/csv]
+  CsvUtil --> HashUtil
+  Pages --> Download[utils/download]
+  Patterns --> Core[core]
+```
+
+## Routing and shell
+
+[`app.tsx`](../../apps/web/src/app.tsx) sets `BrowserRouter` basename to `/dii-operator`.
+[`app-routes.tsx`](../../apps/web/src/routes/app-routes.tsx) nests section routes in `MainLayout`:
+
+| Path | Page |
+| ---- | ---- |
+| `/` | Overview |
+| `/email` | Email normalizer |
+| `/phone` | Phone normalizer |
+| `/csv` | Batch normalizer |
+| `*` | Redirect to `/` |
+
+Vite `base` is `/dii-operator/`.
+The Vite config copies `dist/index.html` to `dist/404.html` so GitHub Pages can serve deep links.
+
+## Hashing posture
+
+Hash helpers live in [`utils/hash/generate.ts`](../../apps/web/src/utils/hash/generate.ts).
+
+- Digests use `crypto.subtle.digest("SHA-256", …)` with `TextEncoder` UTF-8 bytes.
+- Hex and Base64 **must** share one digest when both are needed (`generateSha256Pair` / `generateEmailHashes`).
+- Call sites are **async** and await before updating UI or CSV rows.
+- The app does not use Node `crypto` or `crypto-js`.
+
+Prefer platform download APIs via [`utils/download/blob.ts`](../../apps/web/src/utils/download/blob.ts).
+
+## Build and deploy
+
+The repo is a pnpm workspace.
+Root scripts forward to `apps/web`.
+
+```text
+pnpm install
+pnpm build          # tsc --noEmit && vite build → apps/web/dist
+```
+
+[`.github/workflows/publish.yml`](../../.github/workflows/publish.yml) builds on `main` and uploads `apps/web/dist` to GitHub Pages.
+
+Quality gates (lint workflow):
+
+- `pnpm exec biome ci .`
+- `pnpm build`
+- react-doctor Action
+
+## Public surface and extension points
+
+Extend the product in these places:
+
+| Change | Where |
+| ------ | ----- |
+| New section page | `pages/<Name>/`, register in `routes/app-routes.tsx`, add nav in `MainLayout` |
+| Normalize / hash rules | `utils/email`, `utils/phone`, `utils/hash` (keep Web Crypto) |
+| Batch limits or export shape | `utils/csv/process.ts`, Batch page download handler |
+| Visual tokens | `styles/theme.ts` (MUI palette / typography / overrides) |
+| Shared leaf UI | `components/core` or `components/patterns` |
+
+Do not add a server API for hashing unless the product posture changes on purpose.
+
+## Verification and agent layout
+
+Local verify commands (CI parity):
+
+```bash
+pnpm exec biome ci .
+pnpm build
+pnpm doctor:changed
+```
+
+Agent support lives under `.agents/`:
+
+- `rules/` — project policy (symlink as `.cursor/rules`)
+- `skills/` — domain and design skills
+- `commands/` — `/doctor`, `/check`, `/verify` (symlink as `.cursor/commands`)
+- `hooks/` — Biome / react-doctor after edit; sessionStart context
+- `docs/` — this architecture file
+
+See [AGENTS.md](../../AGENTS.md) for the full index.

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# sessionStart: inject a short pointer to AGENTS.md. Fail open (never block).
+set +e
+cat >/dev/null
+
+CONTEXT='Read AGENTS.md for dii-operator agent guidance. Stack: pnpm 11.8 + Vite SPA in apps/web (basename /dii-operator). Skills: dii-normalize, native-web-apis, typescript-project-structure, jsdoc-typescript-docs, solid-typescript-design, react-doctor. Commands: /doctor /check /verify. Gates: pnpm exec biome ci ., pnpm build, pnpm doctor:changed.'
+
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import json,sys; print(json.dumps({"additional_context": sys.argv[1]}))' "$CONTEXT"
+else
+  # Minimal JSON escape fallback when python3 is unavailable.
+  escaped=${CONTEXT//\\/\\\\}
+  escaped=${escaped//\"/\\\"}
+  printf '{"additional_context":"%s"}\n' "$escaped"
+fi
+
+exit 0

--- a/.agents/rules/web-mui.mdc
+++ b/.agents/rules/web-mui.mdc
@@ -1,0 +1,19 @@
+---
+description: MUI theme and sx styling conventions for apps/web
+globs: apps/web/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# apps/web MUI / theme
+
+## Must
+
+- Drive colors, typography, and component chrome from `apps/web/src/styles/theme.ts`.
+- Prefer MUI `sx` and theme palette tokens (`primary`, `text`, `background`, `divider`) over hard-coded light greys.
+- Load fonts via `@fontsource/sora` imports in `src/index.tsx` (not Google Fonts CDN links).
+
+## Must not
+
+- Add CSS Modules for app chrome solely to satisfy a generic structure checklist.
+- Reintroduce light Material greys (`#f8f9fa`, `grey.50`) on dark theme surfaces.
+- Override heading colors in page `sx` when theme typography already sets them.

--- a/.agents/rules/web-native-apis.mdc
+++ b/.agents/rules/web-native-apis.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Prefer native JavaScript / Web APIs
 
-Minimize bundle size, attack surface, and maintenance cost. Reach for platform APIs before adding imports or changing dependencies.
+Source of truth: `.agents/skills/native-web-apis/SKILL.md`
 
 ## Must
 

--- a/.agents/rules/web-platform.mdc
+++ b/.agents/rules/web-platform.mdc
@@ -1,0 +1,20 @@
+---
+description: Vite, GitHub Pages, and pnpm workspace conventions for dii-operator
+alwaysApply: true
+---
+
+# Platform (Vite / Pages / pnpm)
+
+## Must
+
+- Keep the SPA under `apps/web` with Vite `base: "/dii-operator/"` and React Router basename `/dii-operator`.
+- Preserve the GitHub Pages SPA fallback (`404.html` copy from `index.html` in `vite.config.ts`).
+- Deploy artifact path is `apps/web/dist` (see `.github/workflows/publish.yml`).
+- Use pnpm `11.8.0` and Node `>=22`; add runtime deps via `catalog:` in `pnpm-workspace.yaml`.
+- Run app scripts with `pnpm --filter web …` or root forwards (`pnpm dev`, `pnpm build`, `pnpm start`).
+
+## Must not
+
+- Reintroduce Next.js, npm lockfiles, or `out/` as the Pages publish directory.
+- Change `base` / basename without updating both Vite and Router together.
+- Bypass the catalog with unpinned versions when adding shared deps.

--- a/.agents/rules/web-react-doctor.mdc
+++ b/.agents/rules/web-react-doctor.mdc
@@ -1,0 +1,18 @@
+---
+description: Run react-doctor after React edits in apps/web
+globs: apps/web/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# apps/web react-doctor
+
+Source of truth: `.agents/skills/react-doctor/SKILL.md`
+
+## Must
+
+- After meaningful React code changes, run `pnpm doctor:changed` and fix regressions before finishing.
+- Invoke react-doctor only via root `pnpm run doctor*` scripts (pinned catalog version).
+
+## Must not
+
+- Call `npx react-doctor@latest` or an unpinned global binary.

--- a/.agents/skills/dii-normalize/SKILL.md
+++ b/.agents/skills/dii-normalize/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dii-normalize
+description: >-
+  Implement and review UID2-oriented email/phone normalization, Web Crypto
+  SHA-256 hashing, and CSV batch export in the DII Operator SPA. Use when
+  changing normalize/hash/CSV utils, processor hooks, or BatchNormalizer.
+trigger: >-
+  email normalize, phone normalize, UID2, SHA-256, Base64 hash, CSV batch,
+  generateSha256, downloadBlob, dii-operator, E.164
+---
+
+# DII normalize and hash
+
+Apply when you change domain logic under `apps/web/src/utils/{email,phone,hash,csv,download}`
+or the email / phone / batch pages and hooks.
+
+Lookup tables: [reference.md](reference.md).
+
+Keywords:
+
+| Keyword | Meaning |
+| --- | --- |
+| **must** | Required. Do not deviate. |
+| **must not** | Forbidden. |
+| **should** | Strongly preferred unless a reviewer agrees otherwise. |
+| **may** | Optional. |
+
+Use together with:
+
+- [native-web-apis](../native-web-apis/SKILL.md) for crypto/download deps
+- [solid-typescript-design](../solid-typescript-design/SKILL.md) for module boundaries
+- [jsdoc-typescript-docs](../jsdoc-typescript-docs/SKILL.md) for comments
+- [typescript-project-structure](../typescript-project-structure/SKILL.md) for file placement
+
+Conflict rule: domain contracts come from this skill; hashing transport from native-web-apis.
+
+---
+
+## 1. Posture
+
+- This app is a **client-only** SPA. Normalization and hashing **must** run in the browser.
+- Hashing **must** use the Web Crypto API via `apps/web/src/utils/hash/generate.ts`.
+- Agents **must not** add `crypto-js`, Node `crypto`, or other hash libraries.
+
+## 2. Email
+
+- Validate then normalize in `utils/email/normalize.ts`.
+- UID2-oriented steps (defaults on): strip whitespace, lowercase, Gmail local-part dot removal, Gmail `+tag` stripping; preserve domain.
+- Hooks **must** await async hash helpers after normalize.
+
+## 3. Phone
+
+- Validate with the permissive E.164-like pattern; normalize to `+` + digits in `utils/phone/normalize.ts`.
+- Preserve the Australian `61` trunk-`0` cleanup already in `normalizePhone`.
+
+## 4. Hashing
+
+- Prefer `generateSha256Pair` / `generateEmailHashes` so hex and Base64 share one digest.
+- Public hash helpers **must** remain `async` (`crypto.subtle.digest`).
+- Call sites (hooks, CSV) **must** await results before setting state or building rows.
+
+## 5. CSV batch
+
+- Cap non-empty lines at **10_000**; reject oversize uploads.
+- Classify cells as email / phone / unknown; skip unknowns; count `skippedRows`.
+- Export via `downloadBlob` (`utils/download/blob.ts`), not `file-saver`.
+
+## 6. Verification
+
+After domain changes:
+
+```bash
+pnpm exec biome ci .
+pnpm build
+```

--- a/.agents/skills/dii-normalize/reference.md
+++ b/.agents/skills/dii-normalize/reference.md
@@ -1,0 +1,37 @@
+# DII normalize — reference
+
+## Module map
+
+| Concern | Path |
+| --- | --- |
+| Email validate / normalize | `apps/web/src/utils/email/normalize.ts` |
+| Phone validate / normalize | `apps/web/src/utils/phone/normalize.ts` |
+| SHA-256 hex / Base64 | `apps/web/src/utils/hash/generate.ts` |
+| CSV process | `apps/web/src/utils/csv/process.ts` |
+| Blob download | `apps/web/src/utils/download/blob.ts` |
+| Email hook | `apps/web/src/hooks/use-email-processor.ts` |
+| Phone hook | `apps/web/src/hooks/use-phone-processor.ts` |
+| Batch UI | `apps/web/src/pages/BatchNormalizer/index.tsx` |
+
+## Hash API surface
+
+| Export | Returns |
+| --- | --- |
+| `generateSha256Hash(value)` | `Promise<string>` hex digest or `""` |
+| `generateBase64Hash(value)` | `Promise<string>` Base64 digest or `""` |
+| `generateEmailHashes(normalized)` | `Promise<EmailHashResult>` |
+| `generateSha256Pair(value)` | `Promise<{ sha256, base64 }>` one digest |
+
+## CSV limits
+
+| Limit | Value |
+| --- | --- |
+| Max non-empty lines | `10_000` |
+| Output headers | Input, Normalized, SHA256, Base64 |
+| Download name | `processed_data.csv` |
+
+## Email normalize checklist
+
+1. Reject empty / invalid format before normalize.
+2. Apply option toggles (whitespace, lowercase, Gmail dots, Gmail plus).
+3. Hash only the normalized string.

--- a/.agents/skills/native-web-apis/SKILL.md
+++ b/.agents/skills/native-web-apis/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: native-web-apis
+description: >-
+  Prefer native JavaScript and Web platform APIs over utility libraries when
+  adding imports or changing dependencies in apps/web. Use when hashing,
+  downloading files, encoding text, or evaluating a new npm dependency.
+trigger: >-
+  Web Crypto, crypto.subtle, native APIs, file download, createObjectURL,
+  TextEncoder, btoa, dependency reduction, crypto-js, file-saver
+---
+
+# Prefer native Web APIs
+
+Minimize bundle size, attack surface, and maintenance cost. Reach for platform
+APIs before adding imports or changing dependencies.
+
+Lookup examples: [reference.md](reference.md).
+
+Keywords:
+
+| Keyword | Meaning |
+| --- | --- |
+| **must** | Required. Do not deviate. |
+| **must not** | Forbidden. |
+| **should** | Strongly preferred unless a reviewer agrees otherwise. |
+| **may** | Optional. |
+
+Related rule: `.agents/rules/web-native-apis.mdc` (thin pointer to this skill).
+
+---
+
+## Must
+
+- Prefer Web Crypto (`crypto.subtle`) for hashing; use `apps/web/src/utils/hash/generate.ts`.
+- Prefer `URL.createObjectURL` + temporary `<a download>` via `utils/download/blob` for downloads.
+- Prefer built-ins (`fetch`, `URL`, `URLSearchParams`, `TextEncoder`/`TextDecoder`, `structuredClone`, `btoa`/`atob`) when they cover the need.
+- Add workspace deps with `catalog:` pins in `pnpm-workspace.yaml` when a library is truly required.
+
+## Must not
+
+- Add a third-party package solely to wrap a one-liner platform API.
+- Reintroduce `crypto-js` or `file-saver` without a documented platform gap and explicit user approval.
+- Use Node-only APIs (`node:crypto`, `Buffer`) in browser app code.
+
+## Should
+
+- Encode strings with `TextEncoder` (UTF-8) before `subtle.digest`.
+- Derive hex and Base64 from one digest when both are needed.
+- Revoke object URLs after download clicks.
+
+## When a library is justified
+
+A dependency **may** be added when:
+
+- The platform API is missing in supported browsers and a polyfill is unacceptable, or
+- The problem needs a maintained algorithm not in the platform (and MUI/React already do not cover it).
+
+Document the gap in the PR summary.

--- a/.agents/skills/native-web-apis/reference.md
+++ b/.agents/skills/native-web-apis/reference.md
@@ -1,0 +1,37 @@
+# Native Web APIs — reference
+
+## Replacements already in this repo
+
+| Need | Use | Do not use |
+| --- | --- | --- |
+| SHA-256 hex / Base64 | `utils/hash/generate.ts` (`crypto.subtle`) | `crypto-js` |
+| File download | `utils/download/blob.ts` | `file-saver` |
+| UTF-8 bytes | `TextEncoder` | Buffer / iconv |
+
+## Digest → hex / Base64 sketch
+
+```ts
+const digest = await crypto.subtle.digest(
+  "SHA-256",
+  new TextEncoder().encode(value),
+);
+const bytes = new Uint8Array(digest);
+const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+let binary = "";
+for (const byte of bytes) {
+  binary += String.fromCharCode(byte);
+}
+const base64 = btoa(binary);
+```
+
+## Download sketch
+
+```ts
+const url = URL.createObjectURL(blob);
+const anchor = document.createElement("a");
+anchor.href = url;
+anchor.download = filename;
+anchor.rel = "noopener";
+anchor.click();
+URL.revokeObjectURL(url);
+```

--- a/.cursor/commands
+++ b/.cursor/commands
@@ -1,0 +1,1 @@
+../.agents/commands

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,5 +1,11 @@
 {
+  "version": 1,
   "hooks": {
+    "sessionStart": [
+      {
+        "command": "sh .agents/hooks/session-start.sh"
+      }
+    ],
     "afterFileEdit": [
       {
         "command": "sh .agents/hooks/biome-after-file-edit.sh"
@@ -8,6 +14,5 @@
         "command": "sh .agents/hooks/react-doctor-after-file-edit.sh"
       }
     ]
-  },
-  "version": 1
+  }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+    cooldown:
+      default-days: 21
+    labels:
+      - dependabot
+      - ecosystem:github-actions
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+    cooldown:
+      default-days: 21
+    labels:
+      - dependabot
+      - ecosystem:npm
+    open-pull-requests-limit: 25

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,37 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pnpm audit
+        run: pnpm audit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,80 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Biome
+        run: pnpm exec biome ci .
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web
+        run: pnpm build
+
+  react-doctor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run React Doctor
+        uses: millionco/react-doctor@938008119a288f2fb47c66a69cd9279a21f31784
+        with:
+          version: "0.9.1"
+          blocking: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web
+        run: pnpm build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        with:
+          path: apps/web/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent and contributor guidance
+
+Structured conventions for AI agents and humans working in this repository. For
+fuller context, see [README.md](README.md).
+
+## Docs
+
+- [`.agents/docs/ARCHITECTURE.md`](.agents/docs/ARCHITECTURE.md) — high-level system architecture and diagrams
+- [DeepWiki](https://deepwiki.com/deangrant/dii-operator) — indexed project wiki (architecture, API, pipeline)
+
+## Rules
+
+- [`.agents/rules/`](.agents/rules/) (symlinked from [`.cursor/rules`](.cursor/rules))
+- [`.agents/rules/web-platform.mdc`](.agents/rules/web-platform.mdc) — always-on Vite / Pages / pnpm policy
+- [`.agents/rules/web-native-apis.mdc`](.agents/rules/web-native-apis.mdc) — prefer Web Crypto and native downloads
+- [`.agents/rules/web-mui.mdc`](.agents/rules/web-mui.mdc) — MUI theme and `sx` conventions
+- [`.agents/rules/web-typescript-structure.mdc`](.agents/rules/web-typescript-structure.mdc) — `apps/web/src` layout
+- [`.agents/rules/web-jsdoc.mdc`](.agents/rules/web-jsdoc.mdc) — JSDoc / comment style
+- [`.agents/rules/web-solid.mdc`](.agents/rules/web-solid.mdc) — SOLID module boundaries
+- [`.agents/rules/web-react-doctor.mdc`](.agents/rules/web-react-doctor.mdc) — run `pnpm doctor:changed` after React edits
+
+## Skills
+
+- [`.agents/skills/`](.agents/skills/)
+- [`.agents/skills/dii-normalize/`](.agents/skills/dii-normalize/) — email/phone normalize, Web Crypto hash, CSV batch
+- [`.agents/skills/native-web-apis/`](.agents/skills/native-web-apis/) — platform APIs over utility libraries
+- [`.agents/skills/typescript-project-structure/`](.agents/skills/typescript-project-structure/) — React folder layers
+- [`.agents/skills/jsdoc-typescript-docs/`](.agents/skills/jsdoc-typescript-docs/) — TypeScript comment conventions
+- [`.agents/skills/solid-typescript-design/`](.agents/skills/solid-typescript-design/) — SOLID in TypeScript
+- [`.agents/skills/react-doctor/`](.agents/skills/react-doctor/) — React diagnostics via pinned `pnpm doctor*`
+
+## Commands
+
+- [`.agents/commands/`](.agents/commands/) (symlinked from [`.cursor/commands`](.cursor/commands))
+- `/doctor` — run `pnpm doctor:changed` (or full scan on request)
+- `/check` — `pnpm exec biome ci .`
+- `/verify` — Biome CI plus `pnpm build`
+
+## Hooks
+
+- Config: [`.cursor/hooks.json`](.cursor/hooks.json)
+- `sessionStart` → [`.agents/hooks/session-start.sh`](.agents/hooks/session-start.sh) injects a short AGENTS pointer
+- `afterFileEdit` → [`.agents/hooks/biome-after-file-edit.sh`](.agents/hooks/biome-after-file-edit.sh) formats/lints the edited file
+- `afterFileEdit` → [`.agents/hooks/react-doctor-after-file-edit.sh`](.agents/hooks/react-doctor-after-file-edit.sh) advisory react-doctor on `src/**/*.ts(x)`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Directly Identifying Information (DII) Operator
+Copyright (c) 2026 Dean Grant
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,126 +1,118 @@
-# Directly Identifying Information (DII) Operator
+# DII Operator
 
-A standardized email and phone number normalization and hashing utility that follows UID2 specifications for email address and phone number processing. This tool ensures consistent normalization and hash generation for identity resolution and data matching purposes.
+DII Operator is a client-only web app for **UID2-oriented** email and phone
+normalization and hashing. It runs in the browser, uses the Web Crypto API for
+SHA-256, and can process a one-column CSV batch. There is no application
+backend.
 
-## Overview
+The Vite + React app lives in `apps/web` inside a pnpm workspace. GitHub Pages
+serves the build under `/dii-operator/`.
 
-This application implements the UID2 email and phone ormalization and hashing standards, providing a reliable way to generate consistent, standardized hashes. The tool is particularly useful for:
+## What it does
 
-- Identity resolution systems.
-- Data matching and deduplication.
-- Privacy-preserving user identification.
-- Cross-platform user tracking.
+| Section | Path | Purpose |
+| ------- | ---- | ------- |
+| Overview | `/` | Product summary |
+| Email | `/email` | Normalize and hash one email address |
+| Phone | `/phone` | Normalize and hash one phone number |
+| Batch | `/csv` | Normalize and hash a CSV column (up to 10,000 rows) |
 
-## Technical Specifications
+For each accepted value the UI shows:
 
-### Email Normalization Rules
+1. The normalized string
+2. The SHA-256 digest as lowercase hex
+3. The same digest as standard Base64
 
-The application follows the UID2 email normalization standard:
+You can copy each field to the clipboard.
 
-1. **Whitespace Removal**
+## How it works
 
-   - Removes all leading and trailing spaces.
-   - Removes all internal whitespace characters.
+All normalize and hash work runs in the browser. Digests use
+`crypto.subtle.digest("SHA-256", …)` on UTF-8 bytes of the **normalized**
+string. Hex and Base64 share one digest.
 
-2. **Case Normalization**
+### Email (UID2-oriented)
 
-   - Converts all characters to lowercase.
+1. Strip all whitespace.
+2. Convert to lowercase.
+3. For `gmail.com` local parts: remove `.` characters and strip a `+` tag and
+   everything after it.
+4. Keep the domain unchanged.
 
-3. **Gmail-Specific Rules**
+Example: `Jane.Doe+Work@gmail.com` → `janedoe@gmail.com`.
 
-   - Removes all periods (.) from the local part.
-   - For addresses containing a plus sign (+), removes the plus sign and all subsequent characters before the @ symbol.
-   - Example: `Jane.Doe+Work@gmail.com` → `janedoe@gmail.com`.
+### Phone
 
-4. **Domain Preservation**
-   - Maintains the original domain part without modification.
-   - Preserves all characters after the @ symbol.
+1. Remove spaces, dashes, and parentheses.
+2. Keep digits (and a leading `+` if present).
+3. Emit E.164-like form: `+` followed by digits.
+4. For Australian numbers starting with `61` and a trunk `0`, drop that trunk
+   zero (for example `6104…` → `+614…`).
 
-### Phone Number Normalization Rules
+The app does **not** invent a default country code such as `+1`.
 
-The application follows standard phone number normalization rules:
+### Hash outputs
 
-1. **Character Removal**
+| Form | Meaning |
+| ---- | ------- |
+| Hex | Lowercase hexadecimal encoding of the 32-byte SHA-256 digest |
+| Base64 | Standard Base64 encoding of the same 32 bytes |
 
-   - Removes all non-numeric characters (spaces, dashes, parentheses, etc.).
-   - Preserves only digits 0-9.
+## Requirements
 
-2. **Country Code Handling**
+- Node.js 22 or later
+- pnpm 11.8.0 (use Corepack)
 
-   - Ensures country code is present (defaults to +1 for US/Canada).
-   - Removes any '+' prefix from the country code.
-   - Example: `+1 (555) 123-4567` → `15551234567`.
-
-3. **Length Validation**
-   - Validates normalized phone number length (typically 10-15 digits).
-   - Ensures proper formatting for international numbers.
-
-### Hash Generation
-
-The application generates two types of hashes:
-
-1. **SHA-256 Hash**
-
-   - 64-character hexadecimal string.
-   - Generated from the normalized email address.
-   - Example: `b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514`.
-
-2. **Base64 Encoded Hash**
-   - 44-character string.
-   - Base64 encoding of the raw SHA-256 hash bytes.
-   - Example: `tMmiiTI7IaAcPpQPFQ65uMVCWH8av9jw4cwf/F5HVRQ=`.
-
-## Implementation Details
-
-### Dependencies
-
-- Node.js 22 or higher
-- pnpm 11.8.0 (via Corepack)
-
-## Installation
-
-1. Clone the repository:
+## Install and run
 
 ```bash
-git clone [your-repo-url]
-cd [your-repo-name]
-```
-
-2. Enable the pinned pnpm version and install dependencies:
-
-```bash
+git clone https://github.com/deangrant/dii-operator.git
+cd dii-operator
 corepack enable
 corepack prepare pnpm@11.8.0 --activate
 pnpm install
-```
-
-3. Start the development server:
-
-```bash
 pnpm dev
 ```
 
-4. Access the application at [http://localhost:5173](http://localhost:5173)
+Open [http://localhost:5173/dii-operator/](http://localhost:5173/dii-operator/).
+The app uses basename `/dii-operator` to match GitHub Pages.
 
-This repository is a pnpm workspace. The Vite + React app lives in `apps/web`; root scripts (`pnpm dev`, `pnpm build`, `pnpm start`) forward to that package. Use `pnpm start` (or `pnpm --filter web preview`) to serve a production build locally.
+Root scripts forward to `apps/web`:
+
+| Script | Action |
+| ------ | ------ |
+| `pnpm dev` | Vite development server |
+| `pnpm build` | Typecheck and production build → `apps/web/dist` |
+| `pnpm start` | Preview the production build |
 
 ## Usage
 
-### Input Processing
+### Single email or phone
 
-1. Enter an email address or phone number in the input field.
-2. The application automatically validates the input format.
-3. Click "Submit" to process the email address or phone number.
+1. Open **Email** or **Phone**.
+2. Enter a value and submit.
+3. Review normalized, hex, and Base64 outputs. Use the copy control on each
+   field.
 
-### Output Generation
+### CSV batch
 
-The application generates three outputs:
+1. Open **Batch**.
+2. Upload or drop a CSV with one column of emails and/or phones (at most 10,000
+   non-empty lines).
+3. Download `processed_data.csv` with columns Input, Normalized, SHA256, and
+   Base64. Skipped rows are counted in the UI.
 
-1. Normalized email address.
-2. SHA-256 hash (hexadecimal).
-3. Base64 encoded hash.
+## Deploy
 
-Each output can be copied to the clipboard using the copy button.
+CI builds with `pnpm build` and publishes `apps/web/dist` to GitHub Pages. The
+Vite `base` is `/dii-operator/`. The build also writes `404.html` so deep links
+work on Pages.
+
+## Further reading
+
+- [Architecture](.agents/docs/ARCHITECTURE.md) — system shape and module map
+- [AGENTS.md](AGENTS.md) — agent and contributor conventions
+- [DeepWiki](https://deepwiki.com/deangrant/dii-operator) — indexed project wiki
 
 ## License
 


### PR DESCRIPTION
Introduce a shared agent index, system architecture doc, and domain skills so contributors and AI agents share one
accurate map of the Vite SPA. Rewrite the README to match current normalize, hash, CSV, and Pages behavior, and
wire slash commands plus a sessionStart hook into the existing `.agents` layout.

* Add `AGENTS.md` with Docs, Rules, Skills, Commands, Hooks, and DeepWiki links.
* Add `.agents/docs/ARCHITECTURE.md` covering flows, modules, routing, and deploy.
* Add `dii-normalize` and `native-web-apis` skills with reference companions.
* Add platform, MUI, and react-doctor rules; point native-apis at its skill.
* Add `/doctor`, `/check`, and `/verify` under `.agents/commands` with a `.cursor/commands` symlink.
* Add a fail-open `sessionStart` hook and keep Biome plus react-doctor afterFileEdit hooks.
* Rewrite `README.md` for the client-only Web Crypto app, accurate phone rules, and CSV batch.